### PR TITLE
Improve pattern matching of title for ignorable PRs

### DIFF
--- a/src/PullRequests.js
+++ b/src/PullRequests.js
@@ -12,9 +12,10 @@ class PullRequests {
   }
 
   isIgnorable(pr) {
-    const ignoreWords = ['wip', 'dont merge', 'dontmerge', 'donotmerge']
+    const ignoreWords = ['wip', 'dontmerge', 'donotmerge']
     const regex = new RegExp(`(${ignoreWords.join('|')})`, 'i')
-    return !!pr.title.match(regex)
+    const sanitizedTitle = pr.title.replace(/'|\s+/g, '')
+    return !!sanitizedTitle.match(regex)
   }
 
   belongsToOwner(pr) {

--- a/test/PullRequests.test.js
+++ b/test/PullRequests.test.js
@@ -7,7 +7,7 @@ test('.isIgnorable(pr) returns true with matched strings', () => {
     { title: "Don't merge - this is a PR title" },
     { title: "Do not merge - this is a PR title" },
     { title: "[DO NOT MERGE] - this is a PR title" },
-    { title: "WIP - this is a PR title" }
+    { title: "WIP - this is a PR title" },
   ]
 
   for (let pr of pullRequests) {

--- a/test/PullRequests.test.js
+++ b/test/PullRequests.test.js
@@ -1,0 +1,16 @@
+const PullRequests = require('../src/PullRequests')
+
+test('.isIgnorable(pr) returns true with matched strings', () => {
+  const pullRequest = new PullRequests()
+  const pullRequests = [
+    { title: "Dont merge - this is a PR title" },
+    { title: "Don't merge - this is a PR title" },
+    { title: "Do not merge - this is a PR title" },
+    { title: "[DO NOT MERGE] - this is a PR title" },
+    { title: "WIP - this is a PR title" }
+  ]
+
+  for (let pr of pullRequests) {
+    expect(pullRequest.isIgnorable(pr)).toBeTruthy()
+  }
+})

--- a/test/PullRequests.test.js
+++ b/test/PullRequests.test.js
@@ -10,7 +10,7 @@ test('.isIgnorable(pr) returns true with matched strings', () => {
     { title: "WIP - this is a PR title" },
   ]
 
-  for (let pr of pullRequests) {
+  for (const pr of pullRequests) {
     expect(pullRequest.isIgnorable(pr)).toBeTruthy()
   }
 })


### PR DESCRIPTION
Hi @ohbarye! When we used review bot, it seems like PR titles with `[DO NOT MERGE]` or `[DON'T MERGE]` are not being ignored, hence, still being returned in the list of PRs that needs review.

![screen shot 2017-08-15 at 5 37 11 pm](https://user-images.githubusercontent.com/2811885/29310885-21c2b032-81e2-11e7-8041-25c7eaf3f0a8.png)

I did a quick sanitize and pattern matching in order to support this. Please review!

```js
ignoreWords = ['wip', 'dontmerge', 'donotmerge']
regex = new RegExp(ignoreWords.join('|'), 'i')

title = "[Do not merge] This is a PR title"
title.replace(/'|\s+/g, '').match(regex)                  //  ‎✔ MatchObj {...}

title = "[Don't merge] This is another PR title"
title.replace(/'|\s+/g, '').match(regex)                  //  ‎✔ MatchObj {...}
```