### PR TITLE
tomoima525/support label

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ argument | presence | description
 author | Required | You can specify multiple authors with comma separated values. Also `org/team` is available.
 owner | Optional | It allows only one owner. If you specify this argument with `-` (e.g. `-owner:ohbarye`), it excludes pull requests of the owner.
 repo | Optional | You can specify multiple repositories. If you specify this argument with `-` (e.g. `-repo:ohbarye/review-waiting-list-bot`), it excludes pull requests in the repositories.
+label | Optional | You can specify multiple labels. If you specify this argument with `-` (e.g. `-label:enhancement`), it excludes pull requests in the repository.
 
 Besides, the bot accepts random order.
 
@@ -77,5 +78,4 @@ If you do not have it yet, visit https://my.slack.com/services/new/bot and get t
 ### GITHUB_AUTH_TOKEN (required)
 
 GitHub bot API token.
- 
 If you're not familiar with it, see https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ class App {
   }
 
   static ls(bot, message) {
-    const {authors, owner, repo} = new Parser(message.match[1]).parse()
+    const {authors, owner, repo, label} = new Parser(message.match[1]).parse()
 
     const client = new GitHubApiClient()
 
@@ -22,7 +22,7 @@ class App {
       bot.startConversation(message, (err, convo) => {
         convo.say(':memo: Review waiting list!')
 
-        const messages = new PullRequests(prs, owner, repo).convertToSlackMessages()
+        const messages = new PullRequests(prs, owner, repo, label).convertToSlackMessages()
 
         if (messages.length > 0) {
           _.each(messages, (pr) => convo.say(pr))

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -9,6 +9,7 @@ class Parser {
       author: 'multiple',
       owner: 'single',
       repo: 'multiple',
+      label: 'multiple',
     }
   }
 
@@ -17,6 +18,7 @@ class Parser {
       authors: this.extract('author'),
       owner: this.extract('owner'),
       repo: this.extract('repo'),
+      label: this.extract('label'),
     }
   }
 

--- a/src/PullRequests.js
+++ b/src/PullRequests.js
@@ -3,12 +3,13 @@
 const _ = require('lodash')
 
 class PullRequests {
-  constructor(prs, owner, repo) {
+  constructor(prs, owner, repo, label) {
     this.prs = prs
     this.owner = owner
     this.repo = repo
+    this.label = label
 
-    _.bindAll(this, ['belongsToOwner', 'matchesRepo'])
+    _.bindAll(this, ['belongsToOwner', 'matchesRepo', 'matchesLabel'])
   }
 
   isIgnorable(pr) {
@@ -38,6 +39,17 @@ class PullRequests {
     }
   }
 
+  matchesLabel(pr) {
+    if (this.label.value.length > 0) {
+      const result = _.some(this.label.value, (_label) => {
+        return _.flatMap(pr.labels, (label) => label.name).includes(_label)
+      })
+      return (this.label.inclusion ? result : !result)
+    } else {
+      return true
+    }
+  }
+
   formatPullRequest(pr, index) {
     return `${index+1}. \`${pr.title}\` ${pr.html_url} by ${pr.user.login}`
   }
@@ -47,6 +59,7 @@ class PullRequests {
       .reject(this.isIgnorable)
       .filter(this.belongsToOwner)
       .filter(this.matchesRepo)
+      .filter(this.matchesLabel)
       .map(this.formatPullRequest)
       .value()
   }

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -1,7 +1,7 @@
 const Parser = require('../src/Parser')
 
 test('.parse() works with simple arguments', () => {
-  const parser = new Parser("author:cat owner:host repo:pethouse")
+  const parser = new Parser("author:cat owner:host repo:pethouse label:meow")
   expect(parser.parse()).toEqual({
     authors: {
       inclusion: true,
@@ -14,6 +14,10 @@ test('.parse() works with simple arguments', () => {
     repo: {
       inclusion: true,
       value: ['pethouse'],
+    },
+    label: {
+      inclusion: true,
+      value: ['meow'],
     },
   })
 })


### PR DESCRIPTION
Hi @ohbarye thanks for developing a nice bot! 
I added `label` option which allows us to filter with github's labels. Would be nice if you can take a look and welcome this feature :)

Usage:

```
ls author:tomoima525 label:wip
```