### PR TITLE
Support filtering by requested reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ In your Slack room, just call your bot.
 
 ```
 /invite @review-bot
+@review-bot ls author:ohbarye
+```
+
+For more detailed query:
+
+```
+/invite @review-bot
 @review-bot ls author:ohbarye,basan,org/team owner:ohbarye repo:ohbarye/review-waiting-list-bot,rails/rails
 ```
 
@@ -24,6 +31,7 @@ author | Required | You can specify multiple authors with comma separated values
 owner | Optional | It allows only one owner. If you specify this argument with `-` (e.g. `-owner:ohbarye`), it excludes pull requests of the owner.
 repo | Optional | You can specify multiple repositories. If you specify this argument with `-` (e.g. `-repo:ohbarye/review-waiting-list-bot`), it excludes pull requests in the repositories.
 label | Optional | You can specify multiple labels. If you specify this argument with `-` (e.g. `-label:enhancement`), it excludes pull requests in the repository.
+reviewer | Optional | You can specify multiple reviewers. If you specify this argument with `-` (e.g. `-reviewer:ohbarye`), it excludes pull requests in the repository. Regarding review requests feature on GitHub, see https://blog.github.com/2016-12-07-introducing-review-requests/
 
 Besides, the bot accepts random order.
 

--- a/src/GitHubApiClient.js
+++ b/src/GitHubApiClient.js
@@ -36,6 +36,13 @@ class GitHubApiClient {
   //                 "name": "enhancement"
   //               }
   //             ]
+  //           },
+  //           "reviewRequests": {
+  //             "nodes": [
+  //               {
+  //                 "login": "ohbarye"
+  //               },
+  //             ]
   //           }
   //         }
   //       ]
@@ -44,6 +51,7 @@ class GitHubApiClient {
   // }
   getPullRequestsForAuthorQuery(author) {
     // TODO consider pagination
+    // TODO consider requestedReviewer is a team
     return `
       query {
         search(first:100, query:"type:pr author:${author} state:open", type: ISSUE) {
@@ -58,6 +66,15 @@ class GitHubApiClient {
                 nodes {
                   name,
                 },
+              },
+              reviewRequests(first:100) {
+                nodes {
+                  requestedReviewer {
+                    ... on User {
+                      login
+                    },
+                  }
+                }
               },
             }
           },

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -10,6 +10,7 @@ class Parser {
       owner: 'single',
       repo: 'multiple',
       label: 'multiple',
+      reviewer: 'multiple',
     }
   }
 
@@ -19,6 +20,7 @@ class Parser {
       owner: this.extract('owner'),
       repo: this.extract('repo'),
       label: this.extract('label'),
+      reviewer: this.extract('reviewer'),
     }
   }
 

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -1,7 +1,7 @@
 const Parser = require('../src/Parser')
 
 test('.parse() works with simple arguments', () => {
-  const parser = new Parser("author:cat owner:host repo:pethouse label:meow")
+  const parser = new Parser("author:cat owner:host repo:pethouse label:meow reviewer:dog")
   expect(parser.parse()).toEqual({
     authors: {
       inclusion: true,
@@ -18,6 +18,10 @@ test('.parse() works with simple arguments', () => {
     label: {
       inclusion: true,
       value: ['meow'],
+    },
+    reviewer: {
+      inclusion: true,
+      value: ['dog'],
     },
   })
 })

--- a/test/PullRequests.test.js
+++ b/test/PullRequests.test.js
@@ -21,7 +21,7 @@ describe('.belongsToOwner', () => {
   const pr = { url: "https://github.com/ohbarye/review-waiting-list-bot/pull/34" }
 
   test('returns true with matched strings', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       owner: {
         value: 'ohbarye',
         inclusion: true,
@@ -32,7 +32,7 @@ describe('.belongsToOwner', () => {
   })
 
   test('returns false even with matched strings when inclusion is false', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       owner: {
         value: 'ohbarye',
         inclusion: false,
@@ -43,7 +43,7 @@ describe('.belongsToOwner', () => {
   })
 
   test('returns false with unmatched strings', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       owner: {
         value: 'basan',
         inclusion: true,
@@ -58,7 +58,7 @@ describe('.matchesRepo', () => {
   const pr = { url: "https://github.com/ohbarye/review-waiting-list-bot/pull/34" }
 
   test('returns true with matched strings', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       repo: {
         value: ['ohbarye/review-waiting-list-bot'],
         inclusion: true,
@@ -69,7 +69,7 @@ describe('.matchesRepo', () => {
   })
 
   test('returns false even with matched strings when inclusion is false', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       repo: {
         value: ['ohbarye/review-waiting-list-bot'],
         inclusion: false,
@@ -80,7 +80,7 @@ describe('.matchesRepo', () => {
   })
 
   test('returns false with unmatched strings', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       repo: {
         value: ['ohbarye/kpt-bot'],
         inclusion: true,
@@ -95,7 +95,7 @@ describe('.matchesLabel', () => {
   const pr = { labels: { nodes: [{ name: 'enhancement' }] } }
 
   test('returns true with matched strings', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       label: {
         value: ['enhancement'],
         inclusion: true,
@@ -106,7 +106,7 @@ describe('.matchesLabel', () => {
   })
 
   test('returns false even with matched strings when inclusion is false', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       label: {
         value: ['enhancement'],
         inclusion: false,
@@ -117,7 +117,7 @@ describe('.matchesLabel', () => {
   })
 
   test('returns false with unmatched strings', () => {
-    const pullRequest =new PullRequests([], {
+    const pullRequest = new PullRequests([], {
       label: {
         value: ['bug'],
         inclusion: true,
@@ -125,6 +125,54 @@ describe('.matchesLabel', () => {
     })
 
     expect(pullRequest.matchesLabel(pr)).toEqual(false)
+  })
+})
+
+describe('.matchesReviewer', () => {
+  const pr = {
+    reviewRequests: {
+      nodes: [
+        {
+          // When the reviewer is a user
+          requestedReviewer: {
+            login: 'ohbarye',
+          },
+        },
+      ],
+    },
+  }
+
+  test('returns true with matched strings', () => {
+    const pullRequest = new PullRequests([], {
+      reviewer: {
+        value: ['ohbarye'],
+        inclusion: true,
+      },
+    })
+
+    expect(pullRequest.matchesReviewer(pr)).toEqual(true)
+  })
+
+  test('returns false even with matched strings when inclusion is false', () => {
+    const pullRequest = new PullRequests([], {
+      reviewer: {
+        value: ['ohbarye'],
+        inclusion: false,
+      },
+    })
+
+    expect(pullRequest.matchesReviewer(pr)).toEqual(false)
+  })
+
+  test('returns false with unmatched strings', () => {
+    const pullRequest = new PullRequests([], {
+      reviewer: {
+        value: ['butcher'],
+        inclusion: true,
+      },
+    })
+
+    expect(pullRequest.matchesReviewer(pr)).toEqual(false)
   })
 })
 


### PR DESCRIPTION
Close https://github.com/ohbarye/review-waiting-list-bot/issues/32

## Overview

With this PR, I added `reviewer` option allowing us to filter with requested reviewers.

Regarding review requests feature on GitHub, see https://blog.github.com/2016-12-07-introducing-review-requests/

Usage:

```
ls author:ohbarye reviewer:butcher,org/my-team
```