### PR TITLE
Show reviewer names in a PR list

### DIFF
--- a/src/PullRequests.js
+++ b/src/PullRequests.js
@@ -8,7 +8,7 @@ class PullRequests {
     this.label = label
     this.reviewer = reviewer
 
-    _.bindAll(this, ['matchesLabel', 'matchesReviewer'])
+    _.bindAll(this, ['matchesLabel', 'matchesReviewer', 'formatPullRequest', 'reviewersText'])
   }
 
   isIgnorable(pr) {
@@ -47,7 +47,12 @@ class PullRequests {
   }
 
   formatPullRequest(pr, index) {
-    return `${index+1}. \`${pr.title}\` ${pr.url} by ${pr.author.login}`
+    return `${index+1}. \`${pr.title}\` ${pr.url} by ${pr.author.login} ${this.reviewersText(pr.reviewRequests.nodes)}`
+  }
+
+  reviewersText(reviewRequests) {
+    const reviewers = _.map(reviewRequests, rr => (rr.requestedReviewer.login || rr.requestedReviewer.name))
+    return reviewers.length > 0 ? `(reviewer: ${reviewers.join(', ')})` : '(no reviewer assigned)'
   }
 
   convertToSlackMessages() {

--- a/test/PullRequests.test.js
+++ b/test/PullRequests.test.js
@@ -120,16 +120,36 @@ describe('.matchesReviewer', () => {
 })
 
 describe('.formatPullRequest', () => {
-  const pr = {
-    title: 'Add some tests',
-    url: 'https://github.com/ohbarye/review-waiting-list-bot/pull/34',
-    author: { login: 'ohbarye' },
-  }
-
-  test('returns formatted string', () => {
+  test('returns formatted string without reviewer name when no review assigned', () => {
     const pullRequest = new PullRequests([], {})
+    const pr = {
+      title: 'Add some tests',
+      url: 'https://github.com/ohbarye/review-waiting-list-bot/pull/34',
+      author: { login: 'ohbarye' },
+      reviewRequests: {
+        nodes: [],
+      },
+    }
     expect(pullRequest.formatPullRequest(pr, 0)).toEqual(
-      '1. `Add some tests` https://github.com/ohbarye/review-waiting-list-bot/pull/34 by ohbarye'
+      '1. `Add some tests` https://github.com/ohbarye/review-waiting-list-bot/pull/34 by ohbarye (no reviewer assigned)'
+    )
+  })
+
+  test('returns formatted string with reviewer name when someone assigned', () => {
+    const pullRequest = new PullRequests([], {})
+    const pr = {
+      title: 'Add some tests',
+      url: 'https://github.com/ohbarye/review-waiting-list-bot/pull/34',
+      author: { login: 'ohbarye' },
+      reviewRequests: {
+        nodes: [
+          { requestedReviewer: { login:  'basan' }},
+          { requestedReviewer: { name:  'team-b' }},
+        ],
+      },
+    }
+    expect(pullRequest.formatPullRequest(pr, 0)).toEqual(
+      '1. `Add some tests` https://github.com/ohbarye/review-waiting-list-bot/pull/34 by ohbarye (reviewer: basan, team-b)'
     )
   })
 })


### PR DESCRIPTION
## Issue

Closes https://github.com/ohbarye/review-waiting-list-bot/issues/53

## Feature

With this PR, the bot shows requested reviewer names on Slack.

## Screenshots

### When requested review exists

![image](https://user-images.githubusercontent.com/1811616/43653458-11d9adda-9783-11e8-86ed-210b6bf5a565.png)

### When no review assigned

![image](https://user-images.githubusercontent.com/1811616/43653468-19d36a26-9783-11e8-861e-139ea82b2d05.png)
