### PR TITLE
Suppress warning for Botkit

### DIFF
--- a/src/SlackBot.js
+++ b/src/SlackBot.js
@@ -4,7 +4,7 @@ const Botkit = require('botkit')
 
 class SlackBot {
   constructor() {
-    this.controller = Botkit.slackbot({debug: !!process.env.DEBUG})
+    this.controller = Botkit.slackbot({debug: !!process.env.DEBUG, stats_optout: true})
     this.controller.spawn({token: process.env.SLACK_BOT_TOKEN})
       .startRTM((err, _bot, _payload) => {
         if (err) throw new Error('Could not connect to Slack')


### PR DESCRIPTION
## Issue

https://github.com/ohbarye/review-waiting-list-bot/issues/55

I'm thinking that the message about `Botkit Studio statistics` is not an essential problem. Because I was able to reproduce the message, but the bot correctly posted messages to my Slack. 

## Overview

Anyway, it's better to suppress the warning below for Botkit.

```
Botkit Studio statistics are no longer supported. Update your project to the latest version of Botkit, or add `stats_optout: true` to your bot configuration.
```
