### PR TITLE
Include original error if Botkit fails to connect

### DIFF
--- a/src/SlackBot.js
+++ b/src/SlackBot.js
@@ -7,7 +7,7 @@ class SlackBot {
     this.controller = Botkit.slackbot({debug: !!process.env.DEBUG, stats_optout: true})
     this.controller.spawn({token: process.env.SLACK_BOT_TOKEN})
       .startRTM((err, _bot, _payload) => {
-        if (err) throw new Error('Could not connect to Slack')
+        if (err) throw new Error('Could not connect to Slack:', err)
       })
   }
 

--- a/src/SlackBot.js
+++ b/src/SlackBot.js
@@ -7,7 +7,7 @@ class SlackBot {
     this.controller = Botkit.slackbot({debug: !!process.env.DEBUG, stats_optout: true})
     this.controller.spawn({token: process.env.SLACK_BOT_TOKEN})
       .startRTM((err, _bot, _payload) => {
-        if (err) throw new Error('Could not connect to Slack:', err)
+        if (err) throw new Error('Could not connect to Slack: ' + err)
       })
   }
 


### PR DESCRIPTION
Helps users diagnose issues from Botkit by logging the original error